### PR TITLE
Fix Denial of Service

### DIFF
--- a/contracts/ProofOfExistence2.sol
+++ b/contracts/ProofOfExistence2.sol
@@ -7,6 +7,7 @@ contract ProofOfExistence2 {
   // store a proof of existence in the contract state
   // *transactional function*
   function storeProof(bytes32 proof) {
+    if (proofs.length >= 255) { throw; }
     proofs.push(proof);
   }
 
@@ -33,7 +34,7 @@ contract ProofOfExistence2 {
   // returns true if proof is stored
   // *read-only function*
   function hasProof(bytes32 proof) returns (bool) {
-    for (var i = 0; i < proofs.length; i++) {
+    for (uint8 i = 0; i < proofs.length; i++) {
       if (proofs[i] == proof) {
         return true;
       }


### PR DESCRIPTION
hasProof is iterating using a "var". Solidity will infer that a "unit8" is sufficient for this "var". "unit8" variables can hold values in the range 0 - 255.

If proofs grows to 256 elements, the hasProof loop will never terminate, resulting in a DoS. The notarize function is (implicitly) public, so anyone can cause this condition.

Two changes:
1. make "uint8" explicit
2. throw if someone attempts to add a 256th element to the proofs array

Not sure if you care to maintain this code, but might be nice to address in case others use your code to learn. Thanks!